### PR TITLE
Add filter for WWDC-related tweets

### DIFF
--- a/_posts/2014-06-01-wwdc-related.md
+++ b/_posts/2014-06-01-wwdc-related.md
@@ -1,8 +1,8 @@
 ---
 layout: post
-title:  "Large Conversations"
-short: "Big Conversations"
-date:   2013-04-18 15:55:00
+title:  "WWDC and Apple related tweets"
+short: "WWDC tweets"
+date:   2014-06-01 08:23:00
 filter: (?i)(wwdc|Worldwide Developers Conference|apple||i?mac ?(book|mini|pro)?|iphone|ipad|ipod|icloud|imessage|face ?time|mobile ?me|iwork|ilife|ibeacons?|ibooks?|itunes|App Store|ios|os ?x|yosemite|mavericks|steve jobs|jony ive|tim cook|dr.? dre|beats)
 regex: true
 ---

--- a/_posts/2014-06-01-wwdc-related.md
+++ b/_posts/2014-06-01-wwdc-related.md
@@ -1,0 +1,10 @@
+---
+layout: post
+title:  "Large Conversations"
+short: "Big Conversations"
+date:   2013-04-18 15:55:00
+filter: (?i)(wwdc|Worldwide Developers Conference|apple||i?mac ?(book|mini|pro)?|iphone|ipad|ipod|icloud|imessage|face ?time|mobile ?me|iwork|ilife|ibeacons?|ibooks?|itunes|App Store|ios|os ?x|yosemite|mavericks|steve jobs|jony ive|tim cook|dr.? dre|beats)
+regex: true
+---
+
+Mute tweets related to WWDC and Apple.


### PR DESCRIPTION
Created a filter for WWDC (and Apple) related tweets.

Filter initially created by me, but [@ZackaryCorbett](https://twitter.com/ZackaryCorbett/status/473106183952535552) improved it/made it more aggressive.
